### PR TITLE
fix moving identical blocks fails

### DIFF
--- a/vscode-extension/src/blockMode.ts
+++ b/vscode-extension/src/blockMode.ts
@@ -351,10 +351,9 @@ class BlockMode implements vscode.Disposable {
     );
 
     await vscode.workspace.applyEdit(edit);
-    // rollback stale version if edit failed, and exit
+    // rollback stale version if edit made no changes
     if (document.version === this.editorState.staleVersion) {
       this.editorState.staleVersion = oldStaleVersion;
-      return;
     }
 
     const newOffset = direction === "down" ? moveBlockResponse.newSrcStart : moveBlockResponse.newDstStart;


### PR DESCRIPTION
applyEdit can't fail (AFAIK), so we don't need to exit, but we do need
to revert the staleVersion, since the
version won't tick if the edit doesn't
actually change the file content
