### PR TITLE
Fix extension failure in remote SSH

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+# 0.8.1
+
+## Fixed
+
+- Extension not working in remote SSH session ([[#201](https://github.com/selfint/code-blocks/issues/201)]).
+
 # 0.8.0
 
 ## Added 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Fixed
 
-- Extension not working in remote SSH session ([[#201](https://github.com/selfint/code-blocks/issues/201)]).
+- Extension not working in remote SSH session ([#201](https://github.com/selfint/code-blocks/issues/201)). The extension now runs on the local host rather than the remote. This means that parsers are now installed only once, and `npm` is required only on the local machine.
 
 # 0.8.0
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
         "color": "#6295E3",
         "theme": "dark"
     },
-    "version": "0.8.0",
+    "version": "0.8.1",
     "private": true,
     "license": "MIT",
     "engines": {
@@ -36,6 +36,9 @@
         "visualization"
     ],
     "preview": false,
+    "extensionKind": [
+        "ui"
+    ],
     "activationEvents": [
         "onLanguage"
     ],


### PR DESCRIPTION
In case of remote sessions, this makes the extension run on the users local machine, fixing binary dependency issues.
